### PR TITLE
Change type to drupal-library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
   "name": "heykarthikwithu/cycle",
-  "type": "library",
+  "type": "drupal-library",
   "description": "jQuery Cycle Plugin"
 }


### PR DESCRIPTION
Most (maybe... many anyrate) will be using https://github.com/drupal-composer/drupal-project/ as their starter composer.json. That predefines drupal-library as going to web/libraries/{$name}. To match that I wonder about changing to drupal-library as well.